### PR TITLE
chore: include python workspaces

### DIFF
--- a/project.code-workspace
+++ b/project.code-workspace
@@ -6,5 +6,8 @@
     {
       "path": "frontend",
     },
+    {
+      "path": "python"
+    }
   ]
 }


### PR DESCRIPTION
include python can lead to vscode python env auto detect when use vscode workspace