### PR TITLE
feat(ui): Replace page navigation with dialog for agent config

### DIFF
--- a/frontend/src/app/agent/dialog.tsx
+++ b/frontend/src/app/agent/dialog.tsx
@@ -1,141 +1,163 @@
 import { ArrowRight, X } from "lucide-react";
+import { useEffect } from "react";
 import { Link } from "react-router";
 import { useEnableAgent, useGetAgentInfo } from "@/api/agent";
 import { Button } from "@/components/ui/button";
 import AgentAvatar from "@/components/valuecell/agent-avatar";
 import { MarkdownRenderer } from "@/components/valuecell/renderer";
-import { useEffect } from "react";
 
 interface AgentConfigDialogProps {
-    agentName: string;
-    isOpen: boolean;
-    onOpenChange: (open: boolean) => void;
+  agentName: string;
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
 }
 
-export function AgentConfigDialog({ agentName, isOpen, onOpenChange }: AgentConfigDialogProps) {
-    const { data: agent, isLoading: isLoadingAgent } = useGetAgentInfo({
-        agentName: agentName,
+export function AgentConfigDialog({
+  agentName,
+  isOpen,
+  onOpenChange,
+}: AgentConfigDialogProps) {
+  const { data: agent, isLoading: isLoadingAgent } = useGetAgentInfo({
+    agentName: agentName,
+  });
+  const { mutateAsync } = useEnableAgent();
+
+  const handleEnableAgent = async () => {
+    await mutateAsync({
+      agentName: agentName,
+      enabled: !agent?.enabled,
     });
-    const { mutateAsync } = useEnableAgent();
+  };
 
-    const handleEnableAgent = async () => {
-        await mutateAsync({
-            agentName: agentName,
-            enabled: !agent?.enabled,
-        });
-    };
+  const handleEnableAndChat = async () => {
+    await handleEnableAgent();
+    onOpenChange(false);
+  };
 
-    const handleEnableAndChat = async () => {
-        await handleEnableAgent();
+  // Handle escape key
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
         onOpenChange(false);
+      }
     };
 
-    // Handle escape key
-    useEffect(() => {
-        const handleEscape = (e: KeyboardEvent) => {
-            if (e.key === "Escape") {
-                onOpenChange(false);
-            }
-        };
+    if (isOpen) {
+      document.addEventListener("keydown", handleEscape);
+      // Prevent body scroll when dialog is open
+      document.body.style.overflow = "hidden";
+    }
 
-        if (isOpen) {
-            document.addEventListener("keydown", handleEscape);
-            // Prevent body scroll when dialog is open
-            document.body.style.overflow = "hidden";
-        }
+    return () => {
+      document.removeEventListener("keydown", handleEscape);
+      document.body.style.overflow = "unset";
+    };
+  }, [isOpen, onOpenChange]);
 
-        return () => {
-            document.removeEventListener("keydown", handleEscape);
-            document.body.style.overflow = "unset";
-        };
-    }, [isOpen, onOpenChange]);
+  if (!isOpen || (!agent && !isLoadingAgent)) return null;
 
-    if (!isOpen || (!agent && !isLoadingAgent)) return null;
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fade-in-0 fixed inset-0 z-50 animate-in bg-black/50 backdrop-blur-sm"
+        onClick={() => onOpenChange(false)}
+      />
 
-    return (
-        <>
-            {/* Backdrop */}
-            <div className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm animate-in fade-in-0" onClick={() => onOpenChange(false)} />
+      {/* Dialog */}
+      <div
+        className="fixed inset-0 z-50 flex items-center justify-center p-4"
+        onClick={() => onOpenChange(false)}
+      >
+        <div
+          className="fade-in-0 zoom-in-95 relative h-[25vh] w-[25vw] animate-in rounded-xl bg-white shadow-2xl"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {/* Custom close button */}
+          <button
+            type="button"
+            onClick={() => onOpenChange(false)}
+            className="absolute top-3 right-3 z-10 rounded-full p-1.5 transition-colors hover:bg-gray-100"
+          >
+            <X className="h-6 w-6 cursor-pointer" />
+          </button>
 
-            {/* Dialog */}
-            <div className="fixed inset-0 z-50 flex items-center justify-center p-4" onClick={() => onOpenChange(false)}>
-                <div
-                    className="relative h-[25vh] w-[25vw] rounded-xl bg-white shadow-2xl animate-in fade-in-0 zoom-in-95"
-                    onClick={(e) => e.stopPropagation()}>
-                    {/* Custom close button */}
-                    <button
-                        onClick={() => onOpenChange(false)}
-                        className="absolute right-3 top-3 z-10 rounded-full p-1.5 hover:bg-gray-100 transition-colors">
-                        <X className="h-6 w-6 cursor-pointer" />
-                    </button>
+          {/* Main container */}
+          <div className="flex h-full flex-col overflow-hidden rounded-xl">
+            {/* Header Section */}
+            <div className="border-b bg-linear-to-r from-gray-50 to-white px-6 py-4">
+              {/* Agent Info */}
+              <div className="flex items-center space-x-4">
+                <AgentAvatar
+                  agentName={agentName}
+                  className="h-18 w-18 rounded-lg"
+                />
 
-                    {/* Main container */}
-                    <div className="flex h-full flex-col overflow-hidden rounded-xl">
-                        {/* Header Section */}
-                        <div className="border-b bg-linear-to-r from-gray-50 to-white px-6 py-4">
-                            {/* Agent Info */}
-                            <div className="flex items-center space-x-4">
-                                <AgentAvatar agentName={agentName} className="h-18 w-18 rounded-lg" />
+                <div className="flex-1">
+                  <h1 className="cursor-default font-bold text-2xl text-gray-900">
+                    {agent?.display_name}
+                  </h1>
 
-                                <div className="flex-1">
-                                    <h1 className="text-2xl font-bold text-gray-900 cursor-default">{agent?.display_name}</h1>
-
-                                    {/* Tags */}
-                                    <div className="flex flex-wrap gap-1 mt-2">
-                                        {agent?.agent_metadata.tags.map((tag) => (
-                                            <span
-                                                key={tag}
-                                                className="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600 cursor-default">
-                                                {tag}
-                                            </span>
-                                        ))}
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-
-                        {/* Content Section */}
-                        <div className="flex-1 overflow-hidden bg-white">
-                            <div className="h-full overflow-y-auto px-6 py-3">
-                                <div className="prose prose-sm prose-gray max-w-none">
-                                    <MarkdownRenderer content={agent?.description ?? ""} />
-                                </div>
-                            </div>
-                        </div>
-
-                        {/* Bottom Action Buttons */}
-                        <div className="border-t bg-gray-50 px-6 py-3">
-                            <div className="flex items-center justify-end space-x-2">
-                                {agent?.enabled ? (
-                                    <>
-                                        {agentName !== "ValueCellAgent" && (
-                                            <Button
-                                                variant="outline"
-                                                onClick={handleEnableAgent}
-                                                className="px-5 py-3 rounded-md font-semibold">
-                                                Disable
-                                            </Button>
-                                        )}
-                                        <Link
-                                            className="flex items-center gap-2 rounded-md bg-black px-5 py-1.5 font-semibold text-base text-white hover:bg-black/80"
-                                            to={`/agent/${agentName}`}>
-                                            Chat <ArrowRight size={16} />
-                                        </Link>
-                                    </>
-                                ) : (
-                                    <Link
-                                        className="flex items-center gap-2 rounded-md bg-black px-5 py-3 font-semibold text-base text-white hover:bg-black/80"
-                                        to={`/agent/${agentName}`}
-                                        onClick={handleEnableAndChat}>
-                                        Collect and chat
-                                        <ArrowRight size={16} />
-                                    </Link>
-                                )}
-                            </div>
-                        </div>
-                    </div>
+                  {/* Tags */}
+                  <div className="mt-2 flex flex-wrap gap-1">
+                    {agent?.agent_metadata.tags.map((tag) => (
+                      <span
+                        key={tag}
+                        className="inline-flex cursor-default items-center rounded-full bg-gray-100 px-2 py-0.5 font-medium text-gray-600 text-xs"
+                      >
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
                 </div>
+              </div>
             </div>
-        </>
-    );
+
+            {/* Content Section */}
+            <div className="flex-1 overflow-hidden bg-white">
+              <div className="h-full overflow-y-auto px-6 py-3">
+                <div className="prose prose-sm prose-gray max-w-none">
+                  <MarkdownRenderer content={agent?.description ?? ""} />
+                </div>
+              </div>
+            </div>
+
+            {/* Bottom Action Buttons */}
+            <div className="border-t bg-gray-50 px-6 py-3">
+              <div className="flex items-center justify-end space-x-2">
+                {agent?.enabled ? (
+                  <>
+                    {agentName !== "ValueCellAgent" && (
+                      <Button
+                        variant="outline"
+                        onClick={handleEnableAgent}
+                        className="rounded-md px-5 py-3 font-semibold"
+                      >
+                        Disable
+                      </Button>
+                    )}
+                    <Link
+                      className="flex items-center gap-2 rounded-md bg-black px-5 py-1.5 font-semibold text-base text-white hover:bg-black/80"
+                      to={`/agent/${agentName}`}
+                    >
+                      Chat <ArrowRight size={16} />
+                    </Link>
+                  </>
+                ) : (
+                  <Link
+                    className="flex items-center gap-2 rounded-md bg-black px-5 py-3 font-semibold text-base text-white hover:bg-black/80"
+                    to={`/agent/${agentName}`}
+                    onClick={handleEnableAndChat}
+                  >
+                    Collect and chat
+                    <ArrowRight size={16} />
+                  </Link>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
 }

--- a/frontend/src/app/market/agents.tsx
+++ b/frontend/src/app/market/agents.tsx
@@ -1,40 +1,41 @@
 import { useState } from "react";
-import { Link } from "react-router";
 import { useGetAgentList } from "@/api/agent";
 import ScrollContainer from "@/components/valuecell/scroll/scroll-container";
 import { AgentMarketSkeleton } from "@/components/valuecell/skeleton";
-import { AgentCard } from "./components/agent-card";
 import { AgentConfigDialog } from "../agent/dialog";
+import { AgentCard } from "./components/agent-card";
 
 export default function AgentMarket() {
-    const { data: agents = [], isLoading } = useGetAgentList();
-    const [selectedAgent, setSelectedAgent] = useState<string | null>(null);
-    const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const { data: agents = [], isLoading } = useGetAgentList();
+  const [selectedAgent, setSelectedAgent] = useState<string | null>(null);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
 
-    const handleAgentClick = (agentName: string) => {
-        setSelectedAgent(agentName);
-        setIsDialogOpen(true);
-    };
+  const handleAgentClick = (agentName: string) => {
+    setSelectedAgent(agentName);
+    setIsDialogOpen(true);
+  };
 
-    const handleDialogClose = (open: boolean) => {
-        setIsDialogOpen(open);
+  const handleDialogClose = (open: boolean) => {
+    setIsDialogOpen(open);
 
-        if (!open) {
-            setSelectedAgent(null);
-        }
-    };
-
-    if (isLoading) {
-        return <AgentMarketSkeleton />;
+    if (!open) {
+      setSelectedAgent(null);
     }
+  };
 
-    return (
-        <div className="flex size-full flex-col items-center justify-start gap-8 pt-8">
-            {/* Page Title */}
-            <h1 className="w-full text-center font-medium text-3xl leading-7">Agent Market</h1>
+  if (isLoading) {
+    return <AgentMarketSkeleton />;
+  }
 
-            {/* Agent Cards Grid - This is the original one */}
-            {/* <ScrollContainer>
+  return (
+    <div className="flex size-full flex-col items-center justify-start gap-8 pt-8">
+      {/* Page Title */}
+      <h1 className="w-full text-center font-medium text-3xl leading-7">
+        Agent Market
+      </h1>
+
+      {/* Agent Cards Grid - This is the original one */}
+      {/* <ScrollContainer>
                 <div className="mx-auto grid w-3/4 grid-cols-3 gap-4 space-y-4 pb-8">
                     {agents.map((agent) => (
                         <div key={agent.agent_name} className="break-inside-avoid">
@@ -46,21 +47,30 @@ export default function AgentMarket() {
                 </div>
             </ScrollContainer> */}
 
-            {/* Agent Cards Grid */}
-            <ScrollContainer>
-                <div className="mx-auto grid w-3/4 grid-cols-3 gap-4 space-y-4 pb-8">
-                    {agents.map((agent) => (
-                        <div key={agent.agent_name} className="break-inside-avoid">
-                            <div className="cursor-pointer" onClick={() => handleAgentClick(agent.agent_name)}>
-                                <AgentCard agent={agent} className="h-full" />
-                            </div>
-                        </div>
-                    ))}
-                </div>
-            </ScrollContainer>
-
-            {/* Agent Config Dialog */}
-            {selectedAgent && <AgentConfigDialog agentName={selectedAgent} isOpen={isDialogOpen} onOpenChange={handleDialogClose} />}
+      {/* Agent Cards Grid */}
+      <ScrollContainer>
+        <div className="mx-auto grid w-3/4 grid-cols-3 gap-4 space-y-4 pb-8">
+          {agents.map((agent) => (
+            <div key={agent.agent_name} className="break-inside-avoid">
+              <div
+                className="cursor-pointer"
+                onClick={() => handleAgentClick(agent.agent_name)}
+              >
+                <AgentCard agent={agent} className="h-full" />
+              </div>
+            </div>
+          ))}
         </div>
-    );
+      </ScrollContainer>
+
+      {/* Agent Config Dialog */}
+      {selectedAgent && (
+        <AgentConfigDialog
+          agentName={selectedAgent}
+          isOpen={isDialogOpen}
+          onOpenChange={handleDialogClose}
+        />
+      )}
+    </div>
+  );
 }


### PR DESCRIPTION
- Implement AgentConfigDialog component
- Update Agent Market to show agent details in a modal instead of navigation to new page

## 📝 Pull Request Template

### 1. Related Issue
Closes # (issue number)

### Type of Change (select one)
Type of Change: Enhancement

### 3. Description
When clicking on an agent in the agent market, it was redirecting to a new page that only showed minimal agent info - felt like overkill for such little content. Implemented a modal dialog instead that pops up with the agent details, keeping users on the market page for a smoother browsing experience. The modal shows the same info (avatar, name, tags, description) with enable/chat actions at the bottom, and can be closed by clicking outside or pressing ESC.

### 4. Testing
- [x] I have tested this locally.
- [x] I have updated or added relevant tests.

### 5. Checklist
- [x] I have read the [Code of Conduct](./CODE_OF_CONDUCT.md)
- [x] I have followed the [Contributing Guidelines](./CONTRIBUTING.md)
- [x] My changes follow the project's coding style

