### PR TITLE
feat: Allow LAN access

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -75,7 +75,7 @@ export default defineConfig(async () => ({
   server: {
     port: 1420,
     strictPort: true,
-    host: host || false,
+    host: host || "0.0.0.0", // Allow LAN access
     hmr: host
       ? {
           protocol: "ws",


### PR DESCRIPTION
## 📝 Pull Request Template

### 1. Related Issue
None

### 2. Type of Change (select one)
**Type of Change:** Bug Fix?

### 3. Description
**Problem:**
After starting the project via `start.sh`, the frontend dev server only listens on localhost by default, preventing LAN access to the application. Although the backend is correctly configured to listen on `0.0.0.0`, the frontend configuration restricts LAN connectivity.

**Changes Made:**
- Modified file: `frontend/vite.config.ts`
- Changed Vite dev server's `host` configuration from `host || false` to `host || "0.0.0.0"`
- Added inline comment to clarify this enables LAN access

**Impact:**
After this change, users can access the application from other devices on the local network using the server's IP address (e.g., `http://192.168.1.100:1420`).

**Scope:**
- Only affects frontend dev server network binding configuration
- Does not impact production builds
- Backend configuration requires no changes (already supports LAN access by default)

### 4. Testing
- [x] I have tested this locally
- [x] Verified localhost access still works (existing functionality)
- [x] Verified LAN IP access works (new functionality)
- [ ] I have updated or added relevant tests (configuration change, no additional test code needed)

**Testing Steps:**
1. Run `bash start.sh` to start the project
2. Use `hostname -I` or `ip addr` to get the local IP address
3. Access `http://<IP>:1420` from another device on the same network
4. Verify the application loads and functions correctly

### 5. Checklist
- [x] I have read the [Code of Conduct](./CODE_OF_CONDUCT.md)
- [x] I have followed the [Contributing Guidelines](./CONTRIBUTING.md)
- [x] My changes follow the project's coding style
- [x] Code changes include clear comments
- [x] Relevant documentation does not need updates (minor configuration change)

### 6. Additional Notes
**Security Considerations:**
After enabling LAN access, please ensure:
- The local network environment is trusted
- Configure firewall rules to restrict access if necessary
- Use appropriate security configurations in production environments

**Configuration Details:**
- Frontend port: 1420 (now listening on 0.0.0.0)
- Backend port: 8000 (already listening on 0.0.0.0 by default)