### PR TITLE
fix: remove group name in stock list

### DIFF
--- a/frontend/src/app/home/components/stock-list.tsx
+++ b/frontend/src/app/home/components/stock-list.tsx
@@ -52,7 +52,7 @@ function StockList() {
 
   return (
     <StockMenu>
-      <StockMenuHeader>My Stocks</StockMenuHeader>
+      <StockMenuHeader>My Watchlist</StockMenuHeader>
       <ScrollContainer>
         {stockData?.map((stock) => (
           <StockItem key={stock.symbol} stock={stock} />


### PR DESCRIPTION
## 📝 Pull Request Template

### 1. Related Issue
Closes #227 
<img width="658" height="632" alt="image" src="https://github.com/user-attachments/assets/307da5bc-2a4d-4bdc-a740-53bc385793e6" />


### Type of Change (select one)
Type of Change: Bug Fix

### 3. Description
The group name should be "market name" instead of "watchlist name."  
The watchlist does not support custom multiple watchlists.
### 4. Testing
- [x] I have tested this locally.
- [x] I have updated or added relevant tests.

### 5. Checklist
- [x] I have read the [Code of Conduct](./CODE_OF_CONDUCT.md)
- [x] I have followed the [Contributing Guidelines](./CONTRIBUTING.md)
- [x] My changes follow the project's coding style

