### PR TITLE
fix: use StrategyAgent instead of AutoTradingAgent in home page

### DIFF
--- a/frontend/src/mock/agent-data.tsx
+++ b/frontend/src/mock/agent-data.tsx
@@ -15,10 +15,11 @@ export const agentSuggestions: AgentSuggestion[] = [
     decorativeGraphics: <img src={IconGroupPng} alt="IconGroup" />,
   },
   {
-    id: "AutoTradingAgent",
-    title: "Auto Trading",
+    id: "StrategyAgent",
+    title: "Automated Trading",
     icon: <SvgIcon name={AutoTrade} />,
-    description: "Multiple crypto assets and AI-powered trading strategies",
+    description:
+      "Multi-strategy smart trading, automatically execute your strategies",
     bgColor:
       "bg-gradient-to-r from-[#FFFFFF]/70 from-[5.05%] to-[#EAE8FF]/70 to-[100%]",
     decorativeGraphics: <img src={TrendPng} alt="Trend" />,


### PR DESCRIPTION
## 📝 Pull Request Template

### 1. Related Issue
Closes # (issue number)

### Type of Change (select one)
Type of Change: Bug Fix

### 3. Description
use StrategyAgent instead of AutoTradingAgent in home page, AutoTrading Agent is already removed.

### 4. Testing
- [x] I have tested this locally.
- [x] I have updated or added relevant tests.

### 5. Checklist
- [x] I have read the [Code of Conduct](./CODE_OF_CONDUCT.md)
- [x] I have followed the [Contributing Guidelines](./CONTRIBUTING.md)
- [x] My changes follow the project's coding style

