### PR TITLE
fix: add smart sys.path fallback for init_db entrypoint

### DIFF
--- a/python/valuecell/server/db/init_db.py
+++ b/python/valuecell/server/db/init_db.py
@@ -6,6 +6,18 @@ import sys
 from pathlib import Path
 from typing import Optional
 
+# Smart path handling: try import first, add path only if needed
+# This allows running the script directly: uv run valuecell/server/db/init_db.py
+try:
+    import valuecell  # noqa: F401
+except ImportError:
+    # If import fails, add the Python package root to sys.path
+    # Calculate path: init_db.py -> db -> server -> valuecell -> python (root)
+    _current_file = Path(__file__).resolve()
+    _python_root = _current_file.parent.parent.parent.parent
+    if str(_python_root) not in sys.path:
+        sys.path.insert(0, str(_python_root))
+
 from sqlalchemy import inspect, text
 from sqlalchemy.exc import SQLAlchemyError
 


### PR DESCRIPTION
### 1. Related Issue
NA

### 2. Type of Change
Type of Change: Bug Fix 

### 3. Description
Fixes issues when project path contains spaces (e.g., "Mobile Documents" on macOS).

- Add smart path handling in init_db.py to support direct script execution
- Add quotes to all path variables in launch.py for space compatibility
- Manually load .env file and pass via subprocess to avoid shell parsing issues
- Fixes ModuleNotFoundError when running uv run valuecell/server/db/init_db.py
- Fixes environment variable loading failure on paths like 'Example Path'

The changes are backward compatible:
- init_db.py: Only adds path when import fails (try-except pattern)
- launch.py: Quotes work for both standard and space paths
- No impact on users with standard installation paths

### 4. Testing
- ✅ Tested on macOS with path containing spaces
- ✅ Backward compatible with standard paths
- ✅ All services start successfully

### 5. Checklist
- ✅ I have read the [Code of Conduct](./CODE_OF_CONDUCT.md)
- ✅ I have followed the [Contributing Guidelines](./CONTRIBUTING.md)
- ✅ My changes follow the project's coding style
- ✅ Tested locally

