### PR TITLE
fix: template_id was incorrectly resetting when closing a modal

### DIFF
--- a/frontend/src/app/agent/components/strategy-items/modals/create-strategy-modal.tsx
+++ b/frontend/src/app/agent/components/strategy-items/modals/create-strategy-modal.tsx
@@ -275,7 +275,7 @@ const CreateStrategyModal: FC<CreateStrategyModalProps> = ({ children }) => {
 
   const resetAll = () => {
     setCurrentStep(1);
-    setSelectedTemplateId("default");
+    setSelectedTemplateId("");
     form1.reset();
     form2.reset();
     form3.reset();
@@ -719,7 +719,6 @@ const CreateStrategyModal: FC<CreateStrategyModalProps> = ({ children }) => {
                             </FieldLabel>
                             <div className="flex items-center gap-3">
                               <Select
-                                key={selectedTemplateId}
                                 value={field.state.value}
                                 onValueChange={(value) => {
                                   field.handleChange(value);


### PR DESCRIPTION
## 📝 Pull Request Template

### 1. Related Issue
Closes # (issue number)

### Type of Change (select one)
Type of Change: Bug Fix

### 3. Description
fixe a state issue where template_id was incorrectly resetting when closing a modal.

### 4. Testing
- [x] I have tested this locally.
- [x] I have updated or added relevant tests.

### 5. Checklist
- [x] I have read the [Code of Conduct](./CODE_OF_CONDUCT.md)
- [x] I have followed the [Contributing Guidelines](./CONTRIBUTING.md)
- [x] My changes follow the project's coding style

