### PR TITLE
fix(tracker): split useEffect hooks avoid resend, and dynamically retrieve tracker user_id

### DIFF
--- a/frontend/src/app/agent/components/agent-view/common-agent-area.tsx
+++ b/frontend/src/app/agent/components/agent-view/common-agent-area.tsx
@@ -168,20 +168,15 @@ const CommonAgentAreaContent: FC<CommonAgentAreaProps> = ({ agentName }) => {
     if (curConversationId !== conversationId) {
       setCurConversationId(conversationId);
     }
+  }, [setCurConversationId, curConversationId, conversationId]);
 
+  useEffect(() => {
     if (inputValueFromLocation) {
       sendMessage(inputValueFromLocation);
       // Clear the state after using it once to prevent re-triggering on page refresh
       navigate(".", { replace: true, state: {} });
     }
-  }, [
-    sendMessage,
-    setCurConversationId,
-    curConversationId,
-    navigate,
-    conversationId,
-    inputValueFromLocation,
-  ]);
+  }, [inputValueFromLocation, navigate, sendMessage]);
 
   const [inputValue, setInputValue] = useState<string>("");
   const { currentSection } = useMultiSection();

--- a/frontend/src/lib/tracker.ts
+++ b/frontend/src/lib/tracker.ts
@@ -28,7 +28,6 @@ interface TrackerConfig {
 }
 
 interface TrackingParams {
-  user_id: string;
   client_id: string;
   os: string;
   [key: string]: unknown;
@@ -41,7 +40,6 @@ class Tracker {
   constructor(config: TrackerConfig) {
     this.config = config;
     this.params = {
-      user_id: useSystemStore.getState().id,
       client_id: "",
       os: "",
     };
@@ -60,7 +58,6 @@ class Tracker {
       );
 
       this.params = {
-        ...this.params,
         client_id: clientId,
         os: systemInfo,
       };
@@ -77,6 +74,7 @@ class Tracker {
 
     const payload = {
       event,
+      user_id: useSystemStore.getState().id,
       ...this.params,
       ...params,
     };

--- a/frontend/src/store/plugin/tauri-store-state.ts
+++ b/frontend/src/store/plugin/tauri-store-state.ts
@@ -1,3 +1,4 @@
+import { isTauri } from "@tauri-apps/api/core";
 import { load, type Store } from "@tauri-apps/plugin-store";
 import type { StateStorage } from "zustand/middleware";
 import { debounce } from "@/hooks/use-debounce";
@@ -23,11 +24,7 @@ export class TauriStoreState implements StateStorage {
       return;
     }
 
-    const tauriInternals = (
-      window as Window & { __TAURI_INTERNALS__?: unknown }
-    ).__TAURI_INTERNALS__;
-
-    if (!tauriInternals) {
+    if (!isTauri()) {
       // Running in a regular browser; fall back to default persist storage.
       return;
     }


### PR DESCRIPTION
## 📝 Pull Request Template

### 1. Related Issue
Closes # (issue number)

### 2. Type of Change (select one)
Type of Change: Bug Fix

### 3. Description
split useEffect hooks avoid resend, and dynamically retrieve tracker user_id

### 4. Testing
- [x] I have tested this locally.
- [x] I have updated or added relevant tests.

### 5. Checklist
- [x] I have read the [Code of Conduct](./CODE_OF_CONDUCT.md)
- [x] I have followed the [Contributing Guidelines](./CONTRIBUTING.md)
- [x] My changes follow the project's coding style

