### PR TITLE
fix: Introduce LLM wait time

### DIFF
--- a/python/valuecell/agents/common/trading/decision/prompt_based/composer.py
+++ b/python/valuecell/agents/common/trading/decision/prompt_based/composer.py
@@ -49,12 +49,12 @@ class LlmComposer(BaseComposer):
         *,
         default_slippage_bps: int = 25,
         quantity_precision: float = 1e-9,
-        max_llm_wait_time: float = 600.0,
+        max_llm_wait_time_sec: float = 600.0,
     ) -> None:
         self._request = request
         self._default_slippage_bps = default_slippage_bps
         self._quantity_precision = quantity_precision
-        self._max_llm_wait_time = max_llm_wait_time
+        self._max_llm_wait_time_sec = max_llm_wait_time_sec
         cfg = self._request.llm_model_config
         self._model = model_utils.create_model_with_provider(
             provider=cfg.provider,
@@ -204,7 +204,7 @@ class LlmComposer(BaseComposer):
         `LlmPlanProposal`.
         """
         response = await asyncio.wait_for(
-            self.agent.arun(prompt), timeout=self._max_llm_wait_time
+            self.agent.arun(prompt), timeout=self._max_llm_wait_time_sec
         )
         # Agent may return a raw object or a wrapper with `.content`.
         content = getattr(response, "content", None) or response


### PR DESCRIPTION


## 📝 Pull Request Template

### 1. Related Issue
Closes # (issue number)

### 2. Type of Change (select one)
Type of Change: Bug Fix

### 3. Description
Previously, the LLM invocation within the compose method was not subject to a specific timeout, which could lead to indefinite blocking if the underlying LLM service failed to respond or was extremely slow.

This change Adds max_llm_wait_time, which defaults to 10 minutes to ensure that the LLM composition process will time out after the configured duration, preventing the agent from being stuck indefinitely and allowing for graceful error handling.

### 4. Testing
- [x] I have tested this locally.
- [ ] I have updated or added relevant tests.

### 5. Checklist
- [x] I have read the [Code of Conduct](./CODE_OF_CONDUCT.md)
- [x] I have followed the [Contributing Guidelines](./CONTRIBUTING.md)
- [x] My changes follow the project's coding style

