### PR TITLE
Add Docker support for frontendAdd frontend docker support

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,27 +1,12 @@
-FROM node:20-alpine
-
+FROM oven/bun:1-alpine
 
 WORKDIR /app
 
-# Install bun (project uses bun)
-RUN npm install -g bun
-
-# Copy dependency files
 COPY package.json bun.lockb* ./
-
-# Install dependencies
 RUN bun install
 
-# Copy rest of frontend code
 COPY . .
 
-# Expose frontend port
 EXPOSE 1420
 
-# Bind to all interfaces so it's accessible remotely
-ENV HOST=0.0.0.0
-ENV PORT=1420
-
-# Start dev server
 CMD ["bun", "x", "react-router", "dev", "--host", "0.0.0.0"]
-


### PR DESCRIPTION
This PR adds Docker support for the frontend to simplify remote deployment.

A frontend Dockerfile has been added that runs the React Router dev server inside a Docker container and binds it to 0.0.0.0, fixing the issue where port 1420 was inaccessible on remote Linux servers.
