### PR TITLE
fix: guard tracker outside Tauri and make .env override configurable

### DIFF
--- a/frontend/src/lib/tracker.ts
+++ b/frontend/src/lib/tracker.ts
@@ -47,6 +47,8 @@ class Tracker {
   }
 
   private async init() {
+    if (!isTauri()) return;
+
     try {
       const clientId = await invoke<string>("get_client_id");
       const systemInfo = JSON.stringify(

--- a/python/valuecell/__init__.py
+++ b/python/valuecell/__init__.py
@@ -14,11 +14,27 @@ import logging
 
 # Load environment variables as early as possible
 import os
+import warnings
 from pathlib import Path
 
 from valuecell.utils.env import ensure_system_env_dir, get_system_env_path
 
 logger = logging.getLogger(__name__)
+
+
+def _system_env_override_enabled() -> bool:
+    """Return whether system `.env` values should override process env."""
+    return os.getenv("VALUECELL_SYSTEM_ENV_OVERRIDE", "true").lower() == "true"
+
+
+def _install_warning_filters() -> None:
+    """Suppress known third-party startup warnings that are not actionable here."""
+    warnings.filterwarnings(
+        "ignore",
+        message=r"pkg_resources is deprecated as an API\..*",
+        category=UserWarning,
+        module=r"py_mini_racer\.py_mini_racer",
+    )
 
 
 def load_env_file_early() -> None:
@@ -51,9 +67,17 @@ def load_env_file_early() -> None:
                 logger.info(f"⚠️  Failed to prepare system .env: {e}")
 
         if sys_env.exists():
-            # Load with override=True to allow .env file to override system variables
-            # This is especially important for LANG which is often set by the system
-            load_dotenv(sys_env, override=True)
+            override = _system_env_override_enabled()
+            if override:
+                # Local app behavior: system `.env` is the source of truth.
+                load_dotenv(sys_env, override=True)
+            else:
+                # Container behavior: compose values win, persisted model keys fill blanks.
+                from dotenv import dotenv_values
+
+                for key, value in dotenv_values(sys_env).items():
+                    if value is not None and not os.environ.get(key):
+                        os.environ[key] = value
 
             # Optional: Log successful loading if DEBUG is enabled
             if os.getenv("AGENT_DEBUG_MODE", "false").lower() == "true":
@@ -106,12 +130,13 @@ def _load_env_file_manual() -> None:
                             value.startswith("'") and value.endswith("'")
                         ):
                             value = value[1:-1]
-                        # Always set the value (override existing env vars to match dotenv behavior)
-                        os.environ[key] = value
+                        if _system_env_override_enabled() or not os.environ.get(key):
+                            os.environ[key] = value
     except Exception:
         # Fail silently to avoid breaking imports
         pass
 
 
 # Load environment variables immediately when package is imported
+_install_warning_filters()
 load_env_file_early()

--- a/python/valuecell/server/api/app.py
+++ b/python/valuecell/server/api/app.py
@@ -32,11 +32,16 @@ from .routers.watchlist import create_watchlist_router
 from .schemas import AppInfoData, SuccessResponse
 
 
+def _system_env_override_enabled() -> bool:
+    """Return whether system `.env` values should override process env."""
+    return os.getenv("VALUECELL_SYSTEM_ENV_OVERRIDE", "true").lower() == "true"
+
+
 def _ensure_system_env_and_load() -> None:
     """Ensure the system `.env` exists and is loaded; use only the system path.
 
     Behavior:
-    - If the system `.env` exists, load it with `override=True`.
+    - If the system `.env` exists, load it.
     - If not, and the repository has `.env.example`, copy it to the system path and then load.
     - Do not create or load the repository root `.env`.
     """
@@ -57,9 +62,15 @@ def _ensure_system_env_and_load() -> None:
         # Load system .env into process environment
         if sys_env.exists():
             try:
-                from dotenv import load_dotenv
+                from dotenv import dotenv_values, load_dotenv
 
-                load_dotenv(sys_env, override=True)
+                override = _system_env_override_enabled()
+                if override:
+                    load_dotenv(sys_env, override=True)
+                else:
+                    for key, value in dotenv_values(sys_env).items():
+                        if value is not None and not os.environ.get(key):
+                            os.environ[key] = value
             except Exception:
                 # Fallback manual parsing
                 try:
@@ -74,7 +85,10 @@ def _ensure_system_env_and_load() -> None:
                                     value.startswith("'") and value.endswith("'")
                                 ):
                                     value = value[1:-1]
-                                os.environ[key] = value
+                                if _system_env_override_enabled() or not os.environ.get(
+                                    key
+                                ):
+                                    os.environ[key] = value
                 except Exception:
                     pass
     except Exception:

--- a/python/valuecell/server/config/settings.py
+++ b/python/valuecell/server/config/settings.py
@@ -24,7 +24,7 @@ def _default_db_path() -> str:
     Mirrors `.env` location so the SQLite file lives alongside user-level config:
     - macOS: `~/Library/Application Support/ValueCell/valuecell.db`
     - Linux: `~/.config/valuecell/valuecell.db`
-    - Windows: `%APPDATA%\ValueCell\valuecell.db`
+    - Windows: `%APPDATA%\\ValueCell\\valuecell.db`
     """
     system_dir = get_system_env_dir()
     return f"sqlite:///{os.path.join(str(system_dir), 'valuecell.db')}"
@@ -60,7 +60,7 @@ class Settings:
 
         # File Paths
         self.BASE_DIR = PROJECT_ROOT
-        self.LOGS_DIR = self.BASE_DIR / "logs"
+        self.LOGS_DIR = get_system_env_dir() / "logs"
         self.LOGS_DIR.mkdir(exist_ok=True)
 
         # I18n Configuration

--- a/python/valuecell/server/db/__init__.py
+++ b/python/valuecell/server/db/__init__.py
@@ -1,12 +1,16 @@
 """Database package for ValueCell Server."""
 
+from typing import TYPE_CHECKING, Any
+
 from .connection import (
     DatabaseManager,
     get_database_manager,
     get_db,
 )
-from .init_db import DatabaseInitializer, init_database
 from .models import Agent, Asset, Base
+
+if TYPE_CHECKING:
+    from .init_db import DatabaseInitializer
 
 __all__ = [
     # Connection management
@@ -21,3 +25,21 @@ __all__ = [
     "Agent",
     "Asset",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Lazily expose database initialization helpers.
+
+    Importing `init_db` from this package initializer makes
+    `python -m valuecell.server.db.init_db` warn because the module is loaded
+    before runpy executes it as `__main__`.
+    """
+    if name == "DatabaseInitializer":
+        from .init_db import DatabaseInitializer
+
+        return DatabaseInitializer
+    if name == "init_database":
+        from .init_db import init_database
+
+        return init_database
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
- Skip tracker invoke() when not running in Tauri
- Add VALUECELL_SYSTEM_ENV_OVERRIDE to toggle .env override behavior
- Move LOGS_DIR to system config dir; fix Windows path docstring
- Lazy-import DatabaseInitializer to avoid __main__ warning
- Suppress py_mini_racer pkg_resources deprecation warning

